### PR TITLE
add page id to admin title display

### DIFF
--- a/greyjay/people/models.py
+++ b/greyjay/people/models.py
@@ -139,6 +139,9 @@ class ContributorPage(Page):
     def __str__(self):
         return "{} {} - {}".format(self.first_name, self.last_name, self.email)
 
+    def get_admin_display_title(self):
+        return '{} ({})'.format(self.title, self.id)
+
     content_panels = Page.content_panels + [
         FieldPanel('first_name'),
         FieldPanel('last_name'),


### PR DESCRIPTION
Hi Albert,

Please see commit to show the page ID in Wagtail admin for contributors, as per ticket #98

https://projects.torchbox.com/projects/africa-portal/tickets/98

Kind regards,

Rich